### PR TITLE
Use absolute imports in launcher

### DIFF
--- a/src/amp_autoshutdown/__main__.py
+++ b/src/amp_autoshutdown/__main__.py
@@ -6,8 +6,8 @@ import logging
 import sys
 from pathlib import Path
 
-from .config import ConfigManager
-from .logging_setup import configure_logging
+from amp_autoshutdown.config import ConfigManager
+from amp_autoshutdown.logging_setup import configure_logging
 
 LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.service:
-        from .service import run_service
+        from amp_autoshutdown.service import run_service
 
         run_service()
         return 0


### PR DESCRIPTION
## Summary
- update the launcher entry point to import project modules via absolute paths so it works when frozen

## Testing
- powershell -ExecutionPolicy Bypass -File scripts\build_exe.ps1 *(fails: powershell not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe11a49cc8321a5bb38e96768d547