### PR TITLE
Fix PowerShell variables in build script

### DIFF
--- a/scripts/build_exe.ps1
+++ b/scripts/build_exe.ps1
@@ -1,37 +1,50 @@
 param(
-    [string] = "python",
-    [string] = "AmpAutoShutdown",
-    [string] = "dist",
-    [string] = "build"
+    [string]$PythonExe = "python",
+    [string]$ExecutableName = "AmpAutoShutdown",
+    [string]$DistDir = "dist",
+    [string]$BuildDir = "build"
 )
 
-Continue = "Stop"
- = Split-Path -Parent 
-Set-Location 
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepositoryRoot = (Resolve-Path -Path (Join-Path $ScriptDir "..")).Path
+Set-Location $RepositoryRoot
 
 Write-Host "Building single-file executable with PyInstaller" -ForegroundColor Cyan
 
- = "\src;\gui"
+$SourceDir = (Resolve-Path -Path "src").Path
+$GuiDir = (Resolve-Path -Path "gui").Path
+$PathSeparator = [System.IO.Path]::PathSeparator
+$PythonPath = "$SourceDir$PathSeparator$GuiDir"
+$Env:PYTHONPATH = $PythonPath
 
- = @(
+$DataSeparator = if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
+    ";"
+} else {
+    ":"
+}
+$ConfigData = "config.example.toml${DataSeparator}."
+
+$PyInstallerArgs = @(
     "-m", "PyInstaller",
     "--noconfirm",
     "--clean",
     "--onefile",
     "--noconsole",
-    "--name", ,
-    "--distpath", ,
-    "--workpath", ,
+    "--name", $ExecutableName,
+    "--distpath", $DistDir,
+    "--workpath", $BuildDir,
     "--paths", "src",
     "--paths", "gui",
-    "--add-data", "config.example.toml;.",
+    "--add-data", $ConfigData,
     "--collect-all", "PySide6",
     "src/amp_autoshutdown/__main__.py"
 )
 
-&  
-if ( -ne 0) {
-    throw "PyInstaller build failed with exit code "
+& $PythonExe @PyInstallerArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "PyInstaller build failed with exit code $LASTEXITCODE"
 }
 
-Write-Host "Build complete. Executable located in " -ForegroundColor Green
+Write-Host "Build complete. Executable located in $DistDir" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- restore the missing PowerShell sigils on build script parameters and helper variables
- compute repository, PYTHONPATH, and config data separators for PyInstaller before invocation
- ensure the PyInstaller call expands arguments properly and reports failures via `$LASTEXITCODE`

## Testing
- `powershell -ExecutionPolicy Bypass -File 'scripts\build_exe.ps1'`


------
https://chatgpt.com/codex/tasks/task_e_68cbe470e5b48321b6745ff2ca55559b