### PR TITLE
Fix install_service script variable usage

### DIFF
--- a/scripts/install_service.ps1
+++ b/scripts/install_service.ps1
@@ -1,14 +1,13 @@
 param(
-    [string] = "../dist/AmpAutoShutdown.exe"
+    [string]$ExecutablePath = "../dist/AmpAutoShutdown.exe"
 )
 
-Continue = "Stop"
- = Split-Path -Parent System.Management.Automation.InvocationInfo.MyCommand.Path
- = Resolve-Path -Path (Join-Path  )
-
-if (-not (Test-Path )) {
-    throw "Executable not found at "
+$ErrorActionPreference = "Stop"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ExecutableFullPath = Join-Path -Path $ScriptDir -ChildPath $ExecutablePath
+if (-not (Test-Path $ExecutableFullPath)) {
+    throw "Executable not found at $ExecutableFullPath"
 }
-
-Write-Host "Installing service using " -ForegroundColor Cyan
-&  --install-service
+$ResolvedExe = (Resolve-Path -Path $ExecutableFullPath).ProviderPath
+Write-Host "Installing service using $ResolvedExe" -ForegroundColor Cyan
+& $ResolvedExe --install-service


### PR DESCRIPTION
## Summary
- restore parameter and variable names in the install_service PowerShell script
- resolve the executable path relative to the script directory before installing the service

## Testing
- pwsh -ExecutionPolicy Bypass -File scripts/install_service.ps1

------
https://chatgpt.com/codex/tasks/task_e_68cbe717177c8321a89343c8467a9073