### PR TITLE
Document PyInstaller setup for EXE build

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,15 @@ API keys are stored with Windows Credential Manager via `keyring` when available
    ```
 
 ## Building the Single EXE
-```powershell
-powershell -ExecutionPolicy Bypass -File scripts\build_exe.ps1
-```
+1. Activate your virtual environment so the build script can invoke `python -m PyInstaller` from the environment.
+2. Install PyInstaller inside the environment:
+   ```powershell
+   pip install pyinstaller
+   ```
+3. Run the build script:
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File scripts\build_exe.ps1
+   ```
 The script wraps the project with PyInstaller and saves `AmpAutoShutdown.exe` under `dist/`.
 
 ## Logs


### PR DESCRIPTION
## Summary
- note that the EXE build steps should run from an activated virtual environment
- add a prerequisite to install PyInstaller before invoking the PowerShell build script

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68cbecfb909c8321a1b3b0e85aa3b964