### PR TITLE
Switch AMP modules to absolute imports

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -10,7 +10,7 @@ from PySide6 import QtCore, QtWidgets
 
 from amp_autoshutdown.api_amp import AMPClient, AMPAPIError
 from amp_autoshutdown.config import Config, ConfigManager, LOG_DIR, MaintenanceWindow
-from . import service_control
+from amp_autoshutdown_gui import service_control
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/amp_autoshutdown/logging_setup.py
+++ b/src/amp_autoshutdown/logging_setup.py
@@ -6,7 +6,7 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Optional
 
-from .config import LOG_DIR
+from amp_autoshutdown.config import LOG_DIR
 
 LOG_FILE_NAME = "amp_autoshutdown.log"
 LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s - %(message)s"

--- a/src/amp_autoshutdown/monitor.py
+++ b/src/amp_autoshutdown/monitor.py
@@ -8,9 +8,9 @@ from dataclasses import dataclass
 from datetime import datetime, time, timedelta
 from typing import Dict, Optional
 
-from .api_amp import AMPAPIError, AMPClient
-from .config import Config, ConfigManager
-from .logging_setup import configure_logging
+from amp_autoshutdown.api_amp import AMPAPIError, AMPClient
+from amp_autoshutdown.config import Config, ConfigManager
+from amp_autoshutdown.logging_setup import configure_logging
 
 LOGGER = logging.getLogger(__name__)
 SHUTDOWN_COMMAND = ["shutdown", "/s", "/t", "0"]

--- a/src/amp_autoshutdown/service.py
+++ b/src/amp_autoshutdown/service.py
@@ -18,8 +18,8 @@ except ImportError as exc:  # pragma: no cover - handled at runtime on non-Windo
 else:
     IMPORT_ERROR = None
 
-from .config import ConfigManager
-from .monitor import Monitor
+from amp_autoshutdown.config import ConfigManager
+from amp_autoshutdown.monitor import Monitor
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- replace relative imports in amp_autoshutdown logging, monitor, and service modules with package-qualified imports
- update the GUI to reference the service_control helper via the amp_autoshutdown_gui package

## Testing
- python -m compileall src/amp_autoshutdown gui
- pwsh -File scripts/build_exe.ps1 *(fails: PowerShell is not available in this Linux environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf1cb634c8321bf6a20977ce40f84