### PR TITLE
Fix PyInstaller import packaging issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,15 @@ API keys are stored with Windows Credential Manager via `keyring` when available
    ```
 
 ## Building the Single EXE
-```powershell
-powershell -ExecutionPolicy Bypass -File scripts\build_exe.ps1
-```
+1. Activate your virtual environment so the build script can invoke `python -m PyInstaller` from the environment.
+2. Install PyInstaller inside the environment:
+   ```powershell
+   pip install pyinstaller
+   ```
+3. Run the build script:
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File scripts\build_exe.ps1
+   ```
 The script wraps the project with PyInstaller and saves `AmpAutoShutdown.exe` under `dist/`.
 
 ## Logs

--- a/gui/app.py
+++ b/gui/app.py
@@ -10,7 +10,7 @@ from PySide6 import QtCore, QtWidgets
 
 from amp_autoshutdown.api_amp import AMPClient, AMPAPIError
 from amp_autoshutdown.config import Config, ConfigManager, LOG_DIR, MaintenanceWindow
-from . import service_control
+from amp_autoshutdown_gui import service_control
 
 LOGGER = logging.getLogger(__name__)
 

--- a/scripts/build_exe.ps1
+++ b/scripts/build_exe.ps1
@@ -38,6 +38,7 @@ $PyInstallerArgs = @(
     "--paths", "src",
     "--paths", "gui",
     "--add-data", $ConfigData,
+    "--collect-submodules", "amp_autoshutdown_gui",
     "--collect-all", "PySide6",
     "src/amp_autoshutdown/__main__.py"
 )

--- a/src/amp_autoshutdown/logging_setup.py
+++ b/src/amp_autoshutdown/logging_setup.py
@@ -6,7 +6,7 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Optional
 
-from .config import LOG_DIR
+from amp_autoshutdown.config import LOG_DIR
 
 LOG_FILE_NAME = "amp_autoshutdown.log"
 LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s - %(message)s"

--- a/src/amp_autoshutdown/monitor.py
+++ b/src/amp_autoshutdown/monitor.py
@@ -8,9 +8,9 @@ from dataclasses import dataclass
 from datetime import datetime, time, timedelta
 from typing import Dict, Optional
 
-from .api_amp import AMPAPIError, AMPClient
-from .config import Config, ConfigManager
-from .logging_setup import configure_logging
+from amp_autoshutdown.api_amp import AMPAPIError, AMPClient
+from amp_autoshutdown.config import Config, ConfigManager
+from amp_autoshutdown.logging_setup import configure_logging
 
 LOGGER = logging.getLogger(__name__)
 SHUTDOWN_COMMAND = ["shutdown", "/s", "/t", "0"]

--- a/src/amp_autoshutdown/service.py
+++ b/src/amp_autoshutdown/service.py
@@ -18,8 +18,8 @@ except ImportError as exc:  # pragma: no cover - handled at runtime on non-Windo
 else:
     IMPORT_ERROR = None
 
-from .config import ConfigManager
-from .monitor import Monitor
+from amp_autoshutdown.config import ConfigManager
+from amp_autoshutdown.monitor import Monitor
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- switch amp_autoshutdown modules from relative to absolute imports so they work when frozen by PyInstaller
- update the GUI to import service helpers via the published package namespace
- ensure the PyInstaller build collects the entire amp_autoshutdown_gui package

## Testing
- python -m compileall src gui

------
https://chatgpt.com/codex/tasks/task_e_68cbecfb909c8321a1b3b0e85aa3b964